### PR TITLE
Adding a "Date" header to notification emails.

### DIFF
--- a/net/mail/notification/notification.go
+++ b/net/mail/notification/notification.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/rafaeljusto/shelter/config"
 	"github.com/rafaeljusto/shelter/dao"
@@ -161,6 +162,7 @@ func notifyDomain(domain *model.Domain) error {
 			Domain: *domain,
 			From:   config.ShelterConfig.Notification.From,
 			To:     strings.Join(emails, ","),
+			Date:   FormatDate(time.Now()),
 		}
 
 		var msg bytes.Buffer
@@ -214,3 +216,9 @@ func notifyDomain(domain *model.Domain) error {
 
 	return nil
 }
+
+// FormatDate returns a compliant RFC5322 datetime
+func FormatDate(datetime time.Time) string {
+    return date.Format(datetime.RFC1123Z)
+}
+

--- a/templates/notification/en-us.tmpl
+++ b/templates/notification/en-us.tmpl
@@ -1,5 +1,6 @@
 {{$domain := .}}
 
+Date: {{.Date}}
 From: {{.From}}
 To: {{.To}}
 Subject: Misconfiguration on domain {{$domain.FQDN}}

--- a/templates/notification/es-es.tmpl
+++ b/templates/notification/es-es.tmpl
@@ -1,5 +1,6 @@
 {{$domain := .}}
 
+Date: {{.Date}}
 From: {{.From}}
 To: {{.To}}
 Subject: Problema de configuración con el dominio {{$domain.FQDN}}

--- a/templates/notification/pt-br.tmpl
+++ b/templates/notification/pt-br.tmpl
@@ -1,5 +1,6 @@
 {{$domain := .}}
 
+Date: {{.Date}}
 From: {{.From}}
 To: {{.To}}
 Subject: Problema de configuracao com o dominio {{$domain.FQDN}}


### PR DESCRIPTION
The sendmail function requires to set all headers for the email. The lack of a "Date" one was originating weird behaviour with some mail clients. I choose to add the header inside the template, just like "From".
Hope it helps.
Hugo
